### PR TITLE
Check for missing CPPID in request headers

### DIFF
--- a/clients/rest-client-core/src/main/java/uk/gov/justice/services/clients/core/RestClientProcessor.java
+++ b/clients/rest-client-core/src/main/java/uk/gov/justice/services/clients/core/RestClientProcessor.java
@@ -105,6 +105,10 @@ public class RestClientProcessor {
             return responseAsJsonObject;
         }
 
+        if (cppId == null) {
+            throw new RuntimeException(format("%s is required in request header", CPPID));
+        }
+
         final JsonObject metadata = JsonObjects.createObjectBuilderWithFilter(requestMetadata.asJsonObject(), x -> !ID.equals(x))
                 .add(ID, cppId)
                 .build();

--- a/clients/rest-client-core/src/main/java/uk/gov/justice/services/clients/core/RestClientProcessor.java
+++ b/clients/rest-client-core/src/main/java/uk/gov/justice/services/clients/core/RestClientProcessor.java
@@ -2,6 +2,7 @@ package uk.gov.justice.services.clients.core;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.justice.services.clients.core.exception.InvalidResponseException;
 import uk.gov.justice.services.common.converter.StringToJsonObjectConverter;
 import uk.gov.justice.services.core.enveloper.Enveloper;
 import uk.gov.justice.services.messaging.JsonEnvelope;
@@ -106,7 +107,7 @@ public class RestClientProcessor {
         }
 
         if (cppId == null) {
-            throw new RuntimeException(format("%s is required in request header", CPPID));
+            throw new InvalidResponseException(format("Response received is missing %s header", CPPID));
         }
 
         final JsonObject metadata = JsonObjects.createObjectBuilderWithFilter(requestMetadata.asJsonObject(), x -> !ID.equals(x))

--- a/clients/rest-client-core/src/main/java/uk/gov/justice/services/clients/core/exception/InvalidResponseException.java
+++ b/clients/rest-client-core/src/main/java/uk/gov/justice/services/clients/core/exception/InvalidResponseException.java
@@ -1,0 +1,7 @@
+package uk.gov.justice.services.clients.core.exception;
+
+public class InvalidResponseException extends RuntimeException {
+    public InvalidResponseException(String message) {
+        super(message);
+    }
+}

--- a/clients/rest-client-core/src/test/java/uk/gov/justice/services/clients/core/RestClientProcessorIT.java
+++ b/clients/rest-client-core/src/test/java/uk/gov/justice/services/clients/core/RestClientProcessorIT.java
@@ -173,6 +173,28 @@ public class RestClientProcessorIT {
         restClientProcessor.request(endpointDefinition, requestEnvelopeParamAParamB());
     }
 
+    @Test(expected = RuntimeException.class)
+    public void shouldThrowExceptionOnCPPIDMissing() throws Exception {
+
+        final String path = "/my/resource";
+        final String mimetype = format("application/vnd.%s+json", CONTEXT_QUERY_MY_QUERY);
+
+        stubFor(get(urlPathEqualTo(path))
+                .withHeader("Accept", WireMock.equalTo(mimetype))
+                .withQueryParam("paramA", WireMock.equalTo("valueA"))
+                .withQueryParam("paramC", WireMock.equalTo("valueC"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", mimetype)
+                        .withBody(envelopeWithoutMetadataAsJson)));
+
+        Set<QueryParam> queryParams = ImmutableSet.of(new QueryParam("paramA", true), new QueryParam("paramB", false), new QueryParam("paramC", true));
+
+        EndpointDefinition endpointDefinition = new EndpointDefinition(BASE_URI, path, emptySet(), queryParams);
+
+        restClientProcessor.request(endpointDefinition, requestEnvelopeParamAParamC());
+    }
+
     @Test
     public void shouldReturnJsonNullPayloadFor404ResponseCode() throws Exception {
 

--- a/clients/rest-client-core/src/test/java/uk/gov/justice/services/clients/core/RestClientProcessorIT.java
+++ b/clients/rest-client-core/src/test/java/uk/gov/justice/services/clients/core/RestClientProcessorIT.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import uk.gov.justice.services.clients.core.exception.InvalidResponseException;
 import uk.gov.justice.services.common.converter.StringToJsonObjectConverter;
 import uk.gov.justice.services.core.enveloper.Enveloper;
 import uk.gov.justice.services.messaging.JsonEnvelope;
@@ -173,7 +174,7 @@ public class RestClientProcessorIT {
         restClientProcessor.request(endpointDefinition, requestEnvelopeParamAParamB());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = InvalidResponseException.class)
     public void shouldThrowExceptionOnCPPIDMissing() throws Exception {
 
         final String path = "/my/resource";


### PR DESCRIPTION
The current code throws a NullPointerException if the response does not contain a CPPID header. This can occur if the service has been generated outside the framework e.g. a mock service used for integration testing. This change checks for a missing CPPID header and throws an IllegalStateException with a meaningful exception message.