### PR TITLE
Copy metadata context data

### DIFF
--- a/core/src/main/java/uk/gov/justice/services/core/enveloper/Enveloper.java
+++ b/core/src/main/java/uk/gov/justice/services/core/enveloper/Enveloper.java
@@ -3,8 +3,11 @@ package uk.gov.justice.services.core.enveloper;
 import static java.lang.String.format;
 import static uk.gov.justice.services.messaging.DefaultJsonEnvelope.envelopeFrom;
 import static uk.gov.justice.services.messaging.JsonObjectMetadata.CAUSATION;
+import static uk.gov.justice.services.messaging.JsonObjectMetadata.CONTEXT;
 import static uk.gov.justice.services.messaging.JsonObjectMetadata.ID;
 import static uk.gov.justice.services.messaging.JsonObjectMetadata.NAME;
+import static uk.gov.justice.services.messaging.JsonObjectMetadata.SESSION_ID;
+import static uk.gov.justice.services.messaging.JsonObjectMetadata.USER_ID;
 import static uk.gov.justice.services.messaging.JsonObjectMetadata.metadataFrom;
 
 import uk.gov.justice.domain.annotation.Event;
@@ -104,9 +107,17 @@ public class Enveloper {
                 .add(ID, UUID.randomUUID().toString())
                 .add(NAME, name)
                 .add(CAUSATION, createCausation(metadata))
+                .add(CONTEXT, createContext(metadata))
                 .build();
 
         return metadataFrom(jsonObject);
+    }
+
+    private JsonObject createContext(final Metadata metadata) {
+        JsonObjectBuilder context = Json.createObjectBuilder();
+        metadata.sessionId().ifPresent(s -> context.add(SESSION_ID, s));
+        metadata.userId().ifPresent(s -> context.add(USER_ID, s));
+        return context.build();
     }
 
     private JsonArray createCausation(final Metadata metadata) {

--- a/core/src/test/java/uk/gov/justice/services/core/enveloper/EnveloperTest.java
+++ b/core/src/test/java/uk/gov/justice/services/core/enveloper/EnveloperTest.java
@@ -79,6 +79,8 @@ public class EnveloperTest {
         when(envelope.metadata()).thenReturn(
                 metadataOf(COMMAND_UUID, TEST_EVENT_NAME)
                         .withCausation(OLD_CAUSATION_ID)
+                        .withUserId(USER_ID_VALUE.toString())
+                        .withSessionId(SESSION_ID_VALUE.toString())
                         .build());
         when(objectToJsonValueConverter.convert(object)).thenReturn(payload);
 
@@ -90,6 +92,8 @@ public class EnveloperTest {
         assertThat(event.metadata().causation().size(), equalTo(2));
         assertThat(event.metadata().causation().get(0), equalTo(OLD_CAUSATION_ID));
         assertThat(event.metadata().causation().get(1), equalTo(COMMAND_UUID));
+        assertThat(event.metadata().userId().get(), equalTo(USER_ID_VALUE.toString()));
+        assertThat(event.metadata().sessionId().get(), equalTo(SESSION_ID_VALUE.toString()));
         verify(objectToJsonValueConverter, times(1)).convert(object);
     }
 


### PR DESCRIPTION
A fix to allow Enveloper to work when access control is enabled by propagating userId and sessionId.