### PR TITLE
Update bom to use json schema library with fix for date-time format validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ### Fixed
 - JsonSchemaValidationMatcher to look for json schema in correct location
+- JSON schema validation of date-time format fixed by using a forked version of the JSON schema
+validator library
 
 ## [0.35.0] - 2016-11-24
 ### Added

--- a/core/src/main/java/uk/gov/justice/services/core/json/JsonSchemaLoader.java
+++ b/core/src/main/java/uk/gov/justice/services/core/json/JsonSchemaLoader.java
@@ -26,7 +26,6 @@ public class JsonSchemaLoader {
     @Inject
     private Logger logger;
 
-
     /**
      * Locate a JSON schema file on the classpath and load it.
      * @param name the logical name for the JSON type

--- a/core/src/test/java/uk/gov/justice/services/core/json/DefaultJsonSchemaValidatorTest.java
+++ b/core/src/test/java/uk/gov/justice/services/core/json/DefaultJsonSchemaValidatorTest.java
@@ -10,7 +10,6 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.json.JSONObject;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -31,7 +30,7 @@ public class DefaultJsonSchemaValidatorTest {
     private Logger logger;
 
     @Mock
-    private JsonSchemaLoader loader;
+    private JsonSchemaLoader loader = new JsonSchemaLoader();
 
     @Mock
     private Schema schema;
@@ -39,14 +38,10 @@ public class DefaultJsonSchemaValidatorTest {
     @InjectMocks
     private DefaultJsonSchemaValidator validator;
 
-    @Before
-    public void setup() {
-        when(loader.loadSchema(TEST_SCHEMA_NAME)).thenReturn(schema);
-    }
-
     @Test
     public void shouldValidateUsingCorrectSchema() {
         final String json = "{\"rhubarb\": \"value\"}";
+        when(loader.loadSchema(TEST_SCHEMA_NAME)).thenReturn(schema);
 
         validator.validate(json, TEST_SCHEMA_NAME);
 
@@ -55,9 +50,20 @@ public class DefaultJsonSchemaValidatorTest {
     }
 
     @Test
+    public void shouldAcceptDateTimeWithSingleDigitInSecondsFraction() {
+        final String json = "{\"testField\": \"value\", \"created\": \"2011-12-03T10:15:30.1Z\"}";
+        when(loader.loadSchema(TEST_SCHEMA_NAME)).thenReturn(schema);
+
+        validator.validate(json, TEST_SCHEMA_NAME);
+
+        assertLogStatement();
+    }
+
+    @Test
     public void shouldRemoveMetadataFieldFromJsonToBeValidated() {
         final String json = "{\"rhubarb\": \"value\"}";
         final String jsonWithMetadata = "{\"_metadata\": {}, \"rhubarb\": \"value\"}";
+        when(loader.loadSchema(TEST_SCHEMA_NAME)).thenReturn(schema);
 
         validator.validate(jsonWithMetadata, TEST_SCHEMA_NAME);
 

--- a/core/src/test/java/uk/gov/justice/services/core/json/JsonValidationLoggerTest.java
+++ b/core/src/test/java/uk/gov/justice/services/core/json/JsonValidationLoggerTest.java
@@ -41,7 +41,7 @@ public class JsonValidationLoggerTest {
     @Test
     public void shouldHaveTopLevelMessage() throws IOException {
         with(result)
-                .assertEquals("$.message", "#: 2 schema violations found")
+                .assertEquals("$.message", "#: 6 schema violations found")
                 .assertEquals("$.violation", "#");
     }
 
@@ -89,7 +89,6 @@ public class JsonValidationLoggerTest {
     @Test
     public void shouldHaveCorrectNumberOfNodesAtTopLevel() {
         assertThat(result, hasJsonPath("$.causingExceptions", hasSize(2)));
-        assertThat(result, hasJsonPath("$.causingExceptions[0].causingExceptions", hasSize(3)));
     }
 
     @Test
@@ -126,7 +125,6 @@ public class JsonValidationLoggerTest {
 
     private JSONObject badObject() throws IOException {
         final InputStream inputStream = this.getClass().getResourceAsStream(format(JSON_LOCATION_PATTERN, "fail"));
-        final JSONObject schemaJsonObject = new JSONObject(IOUtils.toString(inputStream, defaultCharset().name()));
-        return schemaJsonObject;
+        return new JSONObject(IOUtils.toString(inputStream, defaultCharset().name()));
     }
 }

--- a/core/src/test/resources/json/schema/test-schema.json
+++ b/core/src/test/resources/json/schema/test-schema.json
@@ -6,9 +6,14 @@
     "testField": {
       "id": "/testField",
       "type": "string"
+    },
+    "created": {
+      "type": "string",
+      "format": "date-time"
     }
   },
   "required": [
-    "testField"
+    "testField",
+    "created"
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     </modules>
 
     <properties>
-        <common-bom.version>1.4.0</common-bom.version>
+        <common-bom.version>1.5.1</common-bom.version>
 		<embedded-artemis.version>1.0.0</embedded-artemis.version>
 		<raml-maven-plugin.version>1.3.0</raml-maven-plugin.version>
     </properties>


### PR DESCRIPTION
PR depends on 1.6.0-SNAPSHOT version of common bom, which once released needs to be updated.