### PR TITLE
Avoid race condition in event stream append

### DIFF
--- a/aggregate-snapshot/aggregate-snapshot-service/src/main/java/uk/gov/justice/services/eventsourcing/source/core/SnapshotAwareEnvelopeEventStream.java
+++ b/aggregate-snapshot/aggregate-snapshot-service/src/main/java/uk/gov/justice/services/eventsourcing/source/core/SnapshotAwareEnvelopeEventStream.java
@@ -28,13 +28,6 @@ public class SnapshotAwareEnvelopeEventStream<T extends Aggregate> extends Envel
     }
 
     @Override
-    public long append(final Stream<JsonEnvelope> events) throws EventStreamException {
-        final long currentVersion = super.append(events);
-        createAggregateSnapshotsFor(currentVersion);
-        return currentVersion;
-    }
-
-    @Override
     public long append(final Stream<JsonEnvelope> events, final Tolerance tolerance) throws EventStreamException {
         final long currentVersion = super.append(events, tolerance);
         if (tolerance == CONSECUTIVE) {

--- a/event-sourcing/event-source/src/main/java/uk/gov/justice/services/eventsourcing/source/core/EnvelopeEventStream.java
+++ b/event-sourcing/event-source/src/main/java/uk/gov/justice/services/eventsourcing/source/core/EnvelopeEventStream.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.services.eventsourcing.source.core;
 
+import static uk.gov.justice.services.eventsourcing.source.core.Tolerance.CONSECUTIVE;
+
 import uk.gov.justice.services.eventsourcing.source.core.exception.EventStreamException;
 import uk.gov.justice.services.messaging.JsonEnvelope;
 
@@ -10,7 +12,8 @@ public class EnvelopeEventStream implements EventStream {
 
     private final EventStreamManager eventStreamManager;
     private final UUID id;
-
+    private Long currentVersion;
+    private boolean isRead = false;
 
     EnvelopeEventStream(final UUID id, final EventStreamManager eventStreamManager) {
         this.id = id;
@@ -19,26 +22,28 @@ public class EnvelopeEventStream implements EventStream {
 
     @Override
     public Stream<JsonEnvelope> read() {
-        return eventStreamManager.read(id);
+        markAsReadFrom(0L);
+        return eventStreamManager.read(id).map(this::recordCurrentVersion);
     }
 
     @Override
     public Stream<JsonEnvelope> readFrom(final long version) {
-        return eventStreamManager.readFrom(id, version);
+        markAsReadFrom(version - 1);
+        return eventStreamManager.readFrom(id, version).map(this::recordCurrentVersion);
     }
 
     @Override
     public long append(final Stream<JsonEnvelope> events) throws EventStreamException {
-        return eventStreamManager.append(id, events);
+        return append(events, CONSECUTIVE);
     }
 
     @Override
-    public long append(final Stream<JsonEnvelope> stream, final Tolerance tolerance) throws EventStreamException {
+    public long append(final Stream<JsonEnvelope> events, final Tolerance tolerance) throws EventStreamException {
         switch (tolerance) {
             case NON_CONSECUTIVE:
-                return eventStreamManager.appendNonConsecutively(id, stream);
+                return eventStreamManager.appendNonConsecutively(id, events);
             default:
-                return eventStreamManager.append(id, stream);
+                return isRead ? eventStreamManager.appendAfter(id, events, currentVersion) : eventStreamManager.append(id, events);
         }
     }
 
@@ -49,11 +54,24 @@ public class EnvelopeEventStream implements EventStream {
 
     @Override
     public long getCurrentVersion() {
-        return eventStreamManager.getCurrentVersion(id);
+        return isRead ? currentVersion : eventStreamManager.getCurrentVersion(id);
     }
 
     @Override
     public UUID getId() {
         return id;
+    }
+
+    private JsonEnvelope recordCurrentVersion(final JsonEnvelope event) {
+        currentVersion = event.metadata().version().orElseThrow(() -> new IllegalStateException("Missing version in event from event store"));
+        return event;
+    }
+
+    private synchronized void markAsReadFrom(final long version) {
+        if (isRead) {
+            throw new IllegalStateException("Event stream has already been read");
+        }
+        isRead = true;
+        currentVersion = version;
     }
 }

--- a/event-sourcing/event-source/src/test/java/uk/gov/justice/services/eventsourcing/source/core/EnvelopeEventStreamTest.java
+++ b/event-sourcing/event-source/src/test/java/uk/gov/justice/services/eventsourcing/source/core/EnvelopeEventStreamTest.java
@@ -1,37 +1,65 @@
 package uk.gov.justice.services.eventsourcing.source.core;
 
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.services.messaging.JsonObjectMetadata.metadataWithDefaults;
+import static uk.gov.justice.services.test.utils.core.messaging.JsonEnvelopeBuilder.envelope;
 
 import uk.gov.justice.services.eventsourcing.source.core.exception.EventStreamException;
 import uk.gov.justice.services.messaging.JsonEnvelope;
+import uk.gov.justice.services.messaging.JsonObjectMetadata;
+import uk.gov.justice.services.test.utils.core.messaging.JsonEnvelopeBuilder;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.jayway.jsonassert.impl.matcher.IsCollectionWithSize;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EnvelopeEventStreamTest {
 
-    public static final Long VERSION = 5L;
+    public static final Long VERSION = 3L;
+    public static final Long MAX_VERSION = 4L;
     private static final UUID STREAM_ID = UUID.randomUUID();
+
     @Mock
     EventStreamManager eventStreamManager;
 
     @Mock
     Stream<JsonEnvelope> stream;
 
+    @Captor
+    ArgumentCaptor<Stream<JsonEnvelope>> streamCaptor;
+
     private EventStream eventStream;
 
     @Before
     public void setup() {
         eventStream = new EnvelopeEventStream(STREAM_ID, eventStreamManager);
+        when(eventStreamManager.read(STREAM_ID)).thenReturn(Stream.of(
+                envelope().with(metadataWithDefaults().withVersion(1L)).build(),
+                envelope().with(metadataWithDefaults().withVersion(2L)).build(),
+                envelope().with(metadataWithDefaults().withVersion(3L)).build(),
+                envelope().with(metadataWithDefaults().withVersion(4L)).build()));
+        when(eventStreamManager.readFrom(STREAM_ID, VERSION)).thenReturn(Stream.of(
+                envelope().with(metadataWithDefaults().withVersion(3L)).build(),
+                envelope().with(metadataWithDefaults().withVersion(4L)).build()
+        ));
     }
 
     @Test
@@ -85,10 +113,42 @@ public class EnvelopeEventStreamTest {
     }
 
     @Test
-    public void testGetId() throws Exception {
+    public void shouldGetId() throws Exception {
         final UUID actualId = eventStream.getId();
 
         assertThat(actualId, equalTo(STREAM_ID));
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionIfReadTwice() {
+        eventStream.read();
+        eventStream.read();
+    }
+
+    @Test
+    public void shouldAppendToLastReadVersion() throws Exception {
+        final JsonEnvelope event = envelope().with(metadataWithDefaults()).build();
+        final Stream<JsonEnvelope> events = Stream.of(event);
+
+        eventStream.read().forEach(e -> {});
+        eventStream.append(events);
+
+        verify(eventStreamManager).appendAfter(eq(STREAM_ID), streamCaptor.capture(), eq(MAX_VERSION));
+        final List<JsonEnvelope> appendedEvents = streamCaptor.getValue().collect(toList());
+        assertThat(appendedEvents, hasSize(1));
+        assertThat(appendedEvents.get(0), is(event));
+    }
+
+    @Test
+    public void shouldAppendAnywhereIfStreamNotRead() throws Exception {
+        final JsonEnvelope event = envelope().with(metadataWithDefaults()).build();
+        final Stream<JsonEnvelope> events = Stream.of(event);
+
+        eventStream.append(events);
+
+        verify(eventStreamManager).append(eq(STREAM_ID), streamCaptor.capture());
+        final List<JsonEnvelope> appendedEvents = streamCaptor.getValue().collect(toList());
+        assertThat(appendedEvents, hasSize(1));
+        assertThat(appendedEvents.get(0), is(event));
+    }
 }

--- a/event-sourcing/event-source/src/test/java/uk/gov/justice/services/eventsourcing/source/core/EventStreamManagerTest.java
+++ b/event-sourcing/event-source/src/test/java/uk/gov/justice/services/eventsourcing/source/core/EventStreamManagerTest.java
@@ -115,10 +115,17 @@ public class EventStreamManagerTest {
     }
 
     @Test(expected = VersionMismatchException.class)
-    public void shouldThrowExceptionWhenFromVersionNotCorrect() throws Exception {
+    public void shouldThrowExceptionWhenEventsAreMissing() throws Exception {
         when(eventRepository.getCurrentSequenceIdForStream(STREAM_ID)).thenReturn(CURRENT_VERSION);
 
         eventStreamManager.appendAfter(STREAM_ID, Stream.of(envelope().with(metadataWithDefaults()).build()), INVALID_VERSION);
+    }
+
+    @Test(expected = OptimisticLockingRetryException.class)
+    public void shouldThrowExceptionWhenVersionAlreadyExists() throws Exception {
+        when(eventRepository.getCurrentSequenceIdForStream(STREAM_ID)).thenReturn(CURRENT_VERSION + 1);
+
+        eventStreamManager.appendAfter(STREAM_ID, Stream.of(envelope().with(metadataWithDefaults()).build()), CURRENT_VERSION);
     }
 
     @Test


### PR DESCRIPTION
Fixes #356 by using the maximum version number in the events that have been read instead of getting the version number from the database