### PR TITLE
CRC-5397-Alfresco API to Provide document as PDF

### DIFF
--- a/file/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/requester/AlfrescoFileRequester.java
+++ b/file/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/requester/AlfrescoFileRequester.java
@@ -29,6 +29,10 @@ public class AlfrescoFileRequester implements FileRequester {
     String alfrescoWorkspacePath;
 
     @Inject
+    @GlobalValue(key = "alfrescoPdfContentWorkspacePath", defaultValue = "/service/api/requestpdf/workspace/SpacesStore/")
+    String alfrescoPdfContentWorkspacePath;
+
+    @Inject
     @GlobalValue(key = "alfrescoReadUser")
     String alfrescoReadUser;
 
@@ -48,8 +52,27 @@ public class AlfrescoFileRequester implements FileRequester {
         }
     }
 
+    @Override
+    public Optional<InputStream> requestPdf(final String fileId, final String fileName) {
+        final String mimeType = "application/pdf";
+        try {
+            return ofNullable(restClient.getAsInputStream(alfrescoPdfUriOf(fileId, fileName),
+                    valueOf(mimeType), headersWithUserId(alfrescoReadUser)));
+        } catch (final NotFoundException nfe) {
+            return empty();
+        } catch (final ProcessingException | InternalServerErrorException ex) {
+            throw new FileOperationException(format("Error fetching %s from Alfresco with fileId = %s",
+                    fileName, fileId), ex);
+        }
+    }
+
     private String alfrescoUriOf(final String fileId, final String fileName) {
         return format("%s%s/content/%s", alfrescoWorkspacePath, fileId, fileName);
+    }
+
+    private String alfrescoPdfUriOf(final String fileId, final String fileName) {
+        return format("%s%s/%s", alfrescoPdfContentWorkspacePath, fileId, fileName);
+
     }
 
 }

--- a/file/file-api/src/main/java/uk/gov/justice/services/file/api/requester/FileRequester.java
+++ b/file/file-api/src/main/java/uk/gov/justice/services/file/api/requester/FileRequester.java
@@ -10,12 +10,22 @@ public interface FileRequester {
 
     /**
      * Requests a file from the FileService.
-     * @param fileId - the unique id of the file.
+     *
+     * @param fileId       - the unique id of the file.
      * @param fileMimeType - mime-type of the file.
-     * @param fileName - name of the file.
+     * @param fileName     - name of the file.
      * @return streamed content of the file.
      */
     Optional<InputStream> request(final String fileId, final String fileMimeType, final String fileName);
+
+    /**
+     * Requests for stream the pdf transformation of the file that given by its fileId from the FileService.
+     *
+     * @param fileId   - the unique id of the file.
+     * @param fileName - name of the file.
+     * @return streamed content of the file.
+     */
+    Optional<InputStream> requestPdf(final String fileId, final String fileName);
 
 }
 


### PR DESCRIPTION
Changes made in FileServices in-order to send request for the new API introduced in Alfresco.
This new API will stream a given file with its fileId as a pdf. If the transformation available.