### PR TITLE
Add local dependency install script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,31 @@ A Java framework to support applications utilising CQRS and Event Sourcing archi
 * messaging-jms - Communication with JMS queues/topics
 * metrics - Support for health checks in application components
 * persistence - Support for persistence layer, such as deltaspike.
+
+## How to build and deploy locally without access to build repository
+
+#### Project dependencies
+Clone the following CJSCommonPlatform projects into the same directory level:
+* [maven-super-pom](https://github.com/CJSCommonPlatform/maven-super-pom)
+* [maven-parent-pom](https://github.com/CJSCommonPlatform/maven-parent-pom)
+* [maven-common-bom](https://github.com/CJSCommonPlatform/maven-common-bom)
+* [maven-common](https://github.com/CJSCommonPlatform/maven-common)
+* [raml-maven](https://github.com/CJSCommonPlatform/raml-maven)
+* [embedded-artemis](https://github.com/CJSCommonPlatform/embedded-artemis)
+* [maven-framework-parent-pom](https://github.com/CJSCommonPlatform/maven-framework-parent-pom)
+* [test-utils](https://github.com/CJSCommonPlatform/test-utils)
+* [utilities](https://github.com/CJSCommonPlatform/utilities)
+* [file-service](https://github.com/CJSCommonPlatform/file-service)
+* [json-schema](https://github.com/CJSCommonPlatform/json-schema)
+* [wildfly-maven-plugin](https://github.com/CJSCommonPlatform/wildfly-maven-plugin)
+* [microservice_framework](https://github.com/CJSCommonPlatform/microservice_framework)
+
+#### Run dependency installation script
+Run the install-dependencies.sh script from the microservice_framework directory.  This will checkout 
+and install the required versions of each project.
+
+`./install-dependencies.sh`
+
+#### Finally build and verify the Microservice Framework.
+
+`mvn clean verify`

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# Script to checkout and install locally all Microservice Framework dependencies
+
+#Build versions
+# maven-super-pom
+maven_super_pom_versions=("release-1.0.0")
+
+# maven-parent-pom
+maven_parent_pom_versions=("release-1.1.0" "release-1.2.0" "release-1.4.0" "release-1.4.1")
+
+# maven-common-bom
+maven_parent_bom_versions=("release-1.9.0" "release-1.13.0" "release-1.15.0")
+
+# maven-common
+maven_common_versions=("release-1.6.4" "release-1.6.10" "release-1.6.11")
+
+# raml-maven
+raml_maven_versions=("release-1.5.0")
+
+# embedded-artemis
+embedded_artemis_versions=("release-1.0.0")
+
+# maven-framework-parent-pom
+maven_framework_parent_pom_versions=("release-1.2.0" "release-1.3.0")
+
+# test-utils
+test_utils_versions=("release-1.2.0")
+
+# utilities
+utilities_versions=("release-1.6.0")
+
+# file-service
+file_service_versions=("release-1.8.0")
+
+# json-schema
+json_schema_versions=("release-1.4.1.MoJ.Fork")
+
+# wildfly-maven-plugin
+wildfly_maven_plugin_versions=("master")
+
+# Checkout and install given version
+function installVersion {
+    git checkout ${1}
+    mvn clean install
+}
+
+# Checkout and install array of versions
+function installVersions {
+    versions=("$@")
+    for version in ${versions[@]}; do
+        installVersion ${version}
+    done
+}
+
+cd ../maven-super-pom
+installVersions ${maven_super_pom_versions[@]}
+
+cd ../maven-parent-pom
+installVersions ${maven_parent_pom_versions[@]}
+
+cd ../maven-common-bom
+installVersions ${maven_parent_bom_versions[@]}
+
+cd ../maven-common
+installVersions ${maven_common_versions[@]}
+
+cd ../raml-maven
+installVersions ${raml_maven_versions[@]}
+
+cd ../embedded-artemis
+installVersions ${embedded_artemis_versions[@]}
+
+cd ../maven-framework-parent-pom
+installVersions ${maven_framework_parent_pom_versions[@]}
+
+cd ../test-utils
+installVersions ${test_utils_versions[@]}
+
+cd ../utilities
+installVersions ${utilities_versions[@]}
+
+cd ../file-service
+installVersions ${file_service_versions[@]}
+
+cd ../json-schema
+installVersions ${json_schema_versions[@]}
+
+cd ../wildfly-maven-plugin
+installVersions ${wildfly_maven_plugin_versions[@]}
+
+cd ../microservice_framework


### PR DESCRIPTION
How to build and deploy Microservice Framework locally without access to build repository.  Includes useful script for building and deploying dependencies into the local m2 cache.