### PR TITLE
Fix JavaDocs errors and warnings

### DIFF
--- a/core/src/main/java/uk/gov/justice/services/core/dispatcher/SystemUserUtil.java
+++ b/core/src/main/java/uk/gov/justice/services/core/dispatcher/SystemUserUtil.java
@@ -20,7 +20,7 @@ public class SystemUserUtil {
     /**
      * Replaces userId of the envelope with system userId
      *
-     * @param envelope
+     * @param envelope the JsonEnvelope with userId to be replaced
      * @return envelope with system user id
      */
     public JsonEnvelope asEnvelopeWithSystemUserId(final JsonEnvelope envelope) {

--- a/core/src/main/java/uk/gov/justice/services/core/extension/BeanInstantiater.java
+++ b/core/src/main/java/uk/gov/justice/services/core/extension/BeanInstantiater.java
@@ -16,8 +16,9 @@ public class BeanInstantiater {
     /**
      * Instantiates the bean using CDI BeanManager auto-wiring all the dependencies.
      *
+     * @param <T>  the type of bean
      * @param bean the bean from which to get the instance
-     * @return an instance of the bean
+     * @return an instance of the bean type
      */
     public <T> T instantiate(final Bean<T> bean) {
         return beanManager.getContext(bean.getScope())

--- a/event-sourcing/event-source/src/main/java/uk/gov/justice/services/eventsourcing/source/core/EventStreamManager.java
+++ b/event-sourcing/event-source/src/main/java/uk/gov/justice/services/eventsourcing/source/core/EventStreamManager.java
@@ -45,6 +45,7 @@ public class EventStreamManager {
     /**
      * Get the stream of events.
      *
+     * @param id the UUID of the stream
      * @return the stream of events
      */
     public Stream<JsonEnvelope> read(final UUID id) {
@@ -54,6 +55,8 @@ public class EventStreamManager {
     /**
      * Get the stream of events from the given version.
      *
+     * @param id      the UUID of the stream
+     * @param version the version of the stream
      * @return the stream of events
      */
     public Stream<JsonEnvelope> readFrom(final UUID id, final long version) {
@@ -63,6 +66,7 @@ public class EventStreamManager {
     /**
      * Store a stream of events.
      *
+     * @param id     the id of the stream
      * @param events the stream of events to store
      * @return the current stream version
      * @throws EventStreamException if an event could not be appended
@@ -114,8 +118,10 @@ public class EventStreamManager {
     /**
      * Store a stream of events after the given version.
      *
+     * @param id      the id of the stream
      * @param events  the stream of events to store
      * @param version the version to append from
+     * @return the current version
      * @throws EventStreamException if an event could not be appended
      */
     @Transactional(dontRollbackOn = OptimisticLockingRetryException.class)
@@ -129,6 +135,7 @@ public class EventStreamManager {
     /**
      * Get the current (current maximum) sequence id (version number) for a stream
      *
+     * @param id the id of the stream
      * @return the latest sequence id for the provided steam. 0 when stream is empty.
      */
     public long getCurrentVersion(final UUID id) {

--- a/example-context/example-service/example-query/example-query-view/src/main/java/uk/gov/justice/services/example/cakeshop/query/view/service/RecipeService.java
+++ b/example-context/example-service/example-query/example-query-view/src/main/java/uk/gov/justice/services/example/cakeshop/query/view/service/RecipeService.java
@@ -37,6 +37,9 @@ public class RecipeService {
     /**
      * Get recipes by criteria.
      *
+     * @param pageSize   page size to return
+     * @param recipeName recipe name to search for
+     * @param glutenFree optional gluten free
      * @return List of recipes encapsulated in an {@link RecipesView}.   Never returns null.
      */
     public RecipesView getRecipes(final int pageSize, final Optional<String> recipeName, Optional<Boolean> glutenFree) {

--- a/framework-api/framework-api-event-stream/src/main/java/uk/gov/justice/services/eventsourcing/source/core/EventStream.java
+++ b/framework-api/framework-api-event-stream/src/main/java/uk/gov/justice/services/eventsourcing/source/core/EventStream.java
@@ -22,6 +22,7 @@ public interface EventStream {
     /**
      * Get the stream of events from the given version.
      *
+     * @param version the version of the stream
      * @return the stream of events
      */
     Stream<JsonEnvelope> readFrom(final long version);
@@ -39,11 +40,11 @@ public interface EventStream {
      * Store a stream of events.
      *
      * @param stream    the stream of events to store
-     * @param tolerance - tolerance for optimistic lock errors. <ul> <li/>CONSECUTIVE - store the
+     * @param tolerance - tolerance for optimistic lock errors. <ul> <li>CONSECUTIVE - store the
      *                  given stream of events with consecutive versions only, fail in case of an
-     *                  optimistic lock. <li/>NON_CONSECUTIVE - allows to store the given stream of
-     *                  events with non consecutive version ids, but reduces the risk of throwing
-     *                  optimistic lock error in case of a version conflict.</ul>
+     *                  optimistic lock.</li> <li>NON_CONSECUTIVE - allows to store the given stream
+     *                  of events with non consecutive version ids, but reduces the risk of throwing
+     *                  optimistic lock error in case of a version conflict.</li></ul>
      * @return the current stream version
      * @throws EventStreamException if an event could not be appended
      */

--- a/framework-api/framework-api-rest-client/src/main/java/uk/gov/justice/services/clients/core/EndpointDefinition.java
+++ b/framework-api/framework-api-rest-client/src/main/java/uk/gov/justice/services/clients/core/EndpointDefinition.java
@@ -16,10 +16,11 @@ public class EndpointDefinition {
     /**
      * Constructor.
      *
-     * @param baseUri     the base URI for the endpoint
-     * @param path        the path, with any path parameter names wrapped in curly brackets
-     * @param pathParams  a set defining the path parameters to expect
-     * @param queryParams a set defining the query parameters this endpoint can take
+     * @param baseUri           the base URI for the endpoint
+     * @param path              the path, with any path parameter names wrapped in curly brackets
+     * @param pathParams        a set defining the path parameters to expect
+     * @param queryParams       a set defining the query parameters this endpoint can take
+     * @param responseMediaType the response media type of the endpoint
      */
     public EndpointDefinition(final String baseUri, final String path, final Set<String> pathParams,
                               final Set<QueryParam> queryParams, final String responseMediaType) {

--- a/generators/generators-test-utils/src/main/java/uk/gov/justice/services/generators/test/utils/reflection/ReflectionUtil.java
+++ b/generators/generators-test-utils/src/main/java/uk/gov/justice/services/generators/test/utils/reflection/ReflectionUtil.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,6 +16,7 @@ public final class ReflectionUtil {
     }
 
     /**
+     * @param clazz - class type
      * @return - list of methods of the clazz
      */
     public static List<Method> methodsOf(final Class<?> clazz) {
@@ -31,6 +31,7 @@ public final class ReflectionUtil {
      * @param object     - object to modify
      * @param fieldName  - name of the field belonging to the object
      * @param fieldValue - value of the field to be set
+     * @throws IllegalAccessException if unable to access field
      */
     public static void setField(final Object object, final String fieldName, final Object fieldValue)
             throws IllegalAccessException {
@@ -42,6 +43,8 @@ public final class ReflectionUtil {
     /**
      * Searches for a field in the given class by reflection
      *
+     * @param clazz     - class type
+     * @param fieldName - name of field in class
      * @return - field belonging to the given clazz with the given fieldName
      */
     public static Field fieldOf(final Class<?> clazz, final String fieldName) {
@@ -54,6 +57,7 @@ public final class ReflectionUtil {
     /**
      * returns first method of the given class
      *
+     * @param clazz - class type
      * @return - first method of the given clazz
      */
     public static Method firstMethodOf(final Class<?> clazz) {
@@ -64,6 +68,8 @@ public final class ReflectionUtil {
     /**
      * returns method of the given class with the given name
      *
+     * @param clazz      - class type
+     * @param methodName - name of method in class
      * @return -  method of the given class with the given name
      */
     public static Method methodOf(final Class<?> clazz, final String methodName) {

--- a/generators/rest-adapter-core/src/main/java/uk/gov/justice/services/adapter/rest/cors/CorsFilter.java
+++ b/generators/rest-adapter-core/src/main/java/uk/gov/justice/services/adapter/rest/cors/CorsFilter.java
@@ -43,6 +43,8 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
 
     /**
      * Put "*" if you want to accept all origins
+     *
+     * @return set of allowed origins
      */
     public Set<String> getAllowedOrigins() {
         return allowedOrigins;
@@ -50,6 +52,8 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
 
     /**
      * Defaults to true
+     *
+     * @return state of allowCredentials
      */
     public boolean isAllowCredentials() {
         return allowCredentials;
@@ -61,6 +65,8 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
 
     /**
      * Will allow all by default
+     *
+     * @return allowed methods
      */
     public String getAllowedMethods() {
         return allowedMethods;
@@ -68,6 +74,8 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
 
     /**
      * Will allow all by default comma delimited string for Access-Control-Allow-Methods
+     *
+     * @param allowedMethods comma delimited string of allowed methods
      */
     public void setAllowedMethods(final String allowedMethods) {
         this.allowedMethods = allowedMethods;
@@ -79,6 +87,8 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
 
     /**
      * Will allow all by default comma delimited string for Access-Control-Allow-Headers
+     *
+     * @param allowedHeaders comma delimited string of allow headers
      */
     public void setAllowedHeaders(final String allowedHeaders) {
         this.allowedHeaders = allowedHeaders;
@@ -98,6 +108,8 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
 
     /**
      * comma delimited list
+     *
+     * @param exposedHeaders - comma delimited list of exposed headers
      */
     public void setExposedHeaders(final String exposedHeaders) {
         this.exposedHeaders = exposedHeaders;

--- a/messaging/messaging-core/src/main/java/uk/gov/justice/services/messaging/DefaultJsonEnvelope.java
+++ b/messaging/messaging-core/src/main/java/uk/gov/justice/services/messaging/DefaultJsonEnvelope.java
@@ -40,6 +40,10 @@ public class DefaultJsonEnvelope implements JsonEnvelope {
     /**
      * Please use the Enveloper for creating real envelopes in production code or the
      * JsonEnvelopeBuilder in test-utils for tests.
+     *
+     * @param metadata the metadata to be added to the JsonEnvelope
+     * @param payload  the JsonValue payload to be added to the JsonEnvelope
+     * @return the JsonEnvelope
      */
     @Deprecated
     public static JsonEnvelope envelopeFrom(final Metadata metadata, final JsonValue payload) {
@@ -49,6 +53,11 @@ public class DefaultJsonEnvelope implements JsonEnvelope {
     /**
      * Please use the Enveloper for creating real envelopes in production code or the
      * JsonEnvelopeBuilder in test-utils for tests.
+     *
+     * @param metadataBuilder the metadata builder to create the metadata to be added to the
+     *                        JsonEnvelope
+     * @param payload         the JsonValue payload to be added to the JsonEnvelope
+     * @return the JsonEnvelope
      */
     @Deprecated
     public static JsonEnvelope envelopeFrom(final JsonObjectMetadata.Builder metadataBuilder, final JsonValue payload) {
@@ -58,6 +67,8 @@ public class DefaultJsonEnvelope implements JsonEnvelope {
     /**
      * Please use the Enveloper for creating real envelopes in production code or the
      * JsonEnvelopeBuilder in test-utils for tests.
+     *
+     * @return the Builder
      */
     @Deprecated
     public static Builder envelope() {
@@ -67,6 +78,9 @@ public class DefaultJsonEnvelope implements JsonEnvelope {
     /**
      * Please use the Enveloper for creating real envelopes in production code or the
      * JsonEnvelopeBuilder in test-utils for tests.
+     *
+     * @param envelope the JsonEnvelope that is added to the builder
+     * @return the Builder
      */
     @Deprecated
     public static Builder envelopeFrom(final JsonEnvelope envelope) {
@@ -229,6 +243,8 @@ public class DefaultJsonEnvelope implements JsonEnvelope {
         /**
          * Please use the Enveloper for creating real envelopes in production code or the
          * JsonEnvelopeBuilder in test-utils for tests.
+         *
+         * @return the JsonEnvelope
          */
         @Deprecated
         public JsonEnvelope build() {

--- a/messaging/messaging-core/src/main/java/uk/gov/justice/services/messaging/JSONObjectValueObfuscator.java
+++ b/messaging/messaging-core/src/main/java/uk/gov/justice/services/messaging/JSONObjectValueObfuscator.java
@@ -21,6 +21,7 @@ public class JSONObjectValueObfuscator {
     /**
      * Obfuscates values in the passed json
      *
+     * @param json the JSONObject to obfuscate
      * @return new json with obfuscatedObject values
      */
     public static JSONObject obfuscated(final JSONObject json) {

--- a/messaging/messaging-core/src/main/java/uk/gov/justice/services/messaging/JsonObjectMetadata.java
+++ b/messaging/messaging-core/src/main/java/uk/gov/justice/services/messaging/JsonObjectMetadata.java
@@ -76,6 +76,8 @@ public class JsonObjectMetadata implements Metadata {
     /**
      * Create metadata builder
      *
+     * @param id   the metadata UUID
+     * @param name the metadata name
      * @return metadata builder
      */
     public static Builder metadataOf(final UUID id, final String name) {
@@ -85,6 +87,8 @@ public class JsonObjectMetadata implements Metadata {
     /**
      * Create metadata builder
      *
+     * @param id   the metadata UUID
+     * @param name the metadata name
      * @return metadata builder
      */
     public static Builder metadataOf(final String id, final String name) {
@@ -94,6 +98,7 @@ public class JsonObjectMetadata implements Metadata {
     /**
      * Create metadata builder with random id
      *
+     * @param name the metadata name
      * @return metadata builder
      */
     public static Builder metadataWithRandomUUID(final String name) {

--- a/test-utils/test-utils-common/src/main/java/uk/gov/justice/services/test/utils/common/envelope/TestEnvelopeRecorder.java
+++ b/test-utils/test-utils-common/src/main/java/uk/gov/justice/services/test/utils/common/envelope/TestEnvelopeRecorder.java
@@ -7,7 +7,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * To be used in unit & integration tests for testing invocations of handlers, senders etc..
+ * To be used in unit and integration tests for testing invocations of handlers, senders etc..
  */
 public abstract class TestEnvelopeRecorder {
     private final List<JsonEnvelope> recordedEnvelopes = new LinkedList<>();

--- a/test-utils/test-utils-common/src/main/java/uk/gov/justice/services/test/utils/common/stream/StreamCloseSpy.java
+++ b/test-utils/test-utils-common/src/main/java/uk/gov/justice/services/test/utils/common/stream/StreamCloseSpy.java
@@ -2,7 +2,7 @@ package uk.gov.justice.services.test.utils.common.stream;
 
 /**
  * Class to be used in unit tests to check if a stream has been closed.
- * <br/>
+ *
  * Usage:
  * <pre>
  * {@code

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/helper/PortFinder.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/helper/PortFinder.java
@@ -25,14 +25,14 @@ public final class PortFinder {
 
     /**
      * Check if a port is available and return the same, if available. <br>
-     * 
+     *
      * If the specified port is not available try a random port from<br>
      * 8000 to 9000 a random number of tries between 10 and 20<br>
-     * 
+     *
      * If none of the above works return the passed in port
-     * 
-     * @param port
-     * @return
+     *
+     * @param port the port to check
+     * @return the available port
      */
     public static final int getPortWithRandomPortFallback(final int port) {
         int allocatedport = getPort(port);

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/helper/TypeCheck.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/helper/TypeCheck.java
@@ -18,8 +18,8 @@ import org.hamcrest.TypeSafeMatcher;
  * that should hold for a range of data point
  *
  * @param <T> Type of the Property and must have {@link  Generator} implementation for type T Usage:
- *            typeCheck(RandomGenerator.STRING, s -> s.length() == s.toCharArray().length).withPreCondition(s
- *            -> s.length() < 5).verify(times(5));
+ *            {@code typeCheck(RandomGenerator.STRING, s -> s.length() == s.toCharArray().length)
+ *            .withPreCondition(s -> s.length() < 5).verify(times(5)); }
  */
 public class TypeCheck<T> {
 

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/PollingRequestParamsBuilder.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/PollingRequestParamsBuilder.java
@@ -105,19 +105,22 @@ public class PollingRequestParamsBuilder {
     }
 
     /**
-     * Adds a condition for verifying the response body from a call to a rest endpoint. By default allows all.
+     * Adds a condition for verifying the response body from a call to a rest endpoint. By default
+     * allows all.
      *
      * To use:
-     *      <pre><blockquote>
+     * <pre>
+     *  {@code
      *
      *      new PollingRequestParamsBuilder()
      *          .withResultCondition(json -> json.equals("my-json"))
      *          .build();
      *
-     *      </blockquote></pre>
+     *  }
+     * </pre>
      *
-     * @param resultCondition
-     * @return
+     * @param resultCondition the result condition
+     * @return the PollingRequestParamsBuilder
      */
     public PollingRequestParamsBuilder withResponseBodyCondition(final Predicate<String> resultCondition) {
         this.resultCondition = resultCondition;
@@ -128,7 +131,7 @@ public class PollingRequestParamsBuilder {
      * Adds a pre configured result condition, which verified that all of the names/values exist
      * in the response body json
      *
-     * @See ExpectedJsonValuesResultCondition
+     * {@link ExpectedJsonValuesResultCondition}
      *
      * @param values a Map of property names to values that should exist in the result json
      * @return this

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/PollingRestClient.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/PollingRestClient.java
@@ -47,7 +47,8 @@ public class PollingRestClient {
      *
      * To Use:
      *
-     * <pre><blockquote>
+     * <pre>
+     *  {@code
      *
      *      final String url = "http://localhost:8080/my-context/my/rest/endpoint";
      *      final String mediaType = "application/vnd.notification.query.events+json";
@@ -58,7 +59,8 @@ public class PollingRestClient {
      *
      *      final String json = new PollingRestClient().pollUntilExpectedResponse(pollingRequestParams);
      *
-     * </blockquote></pre>
+     *  }
+     * </pre>
      *
      * The call is configured using <code>PollingRequestParams</code>. This object is most easily
      * created using a <code>PollingRequestParamsBuilder</code> which takes a url and media type and
@@ -72,14 +74,16 @@ public class PollingRestClient {
      *
      * This is best added using the PollingRequestParamsBuilder:
      *
-     * <pre><blockquote>
+     * <pre>
+     *  {@code
      *
      *     final PollingRequestParams pollingRequestParams =
      *          new PollingRequestParamsBuilder(url, mediaType)
      *              .withResponseBodyCondition(json -> json.equals("my-json"))
      *          .build();
      *
-     * </blockquote></pre>
+     *  }
+     * </pre>
      *
      * Expeced status:
      *
@@ -90,17 +94,19 @@ public class PollingRestClient {
      *
      * This is best added using the PollingRequestParamsBuilder:
      *
-     * <pre><blockquote>
+     * <pre>
+     *  {@code
      *
      *     final PollingRequestParams pollingRequestParams =
      *          new PollingRequestParamsBuilder(url, mediaType)
      *              .withExpectedResponseStatus(200)
      *          .build();
      *
-     * </blockquote></pre>
+     *  }
+     * </pre>
      *
      * @param pollingRequestParams all parameters for polling the end point. Best created using the
-     *                             @See PollingRequestParamsBuilder
+     *                             {@link PollingRequestParamsBuilder}
      * @return the response body as a String
      * @throws AssertionError if the request validation fails or no response is found after the
      * specified number of retires

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/RestPoller.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/RestPoller.java
@@ -31,7 +31,8 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  * To Use:
  *
  * Poll until the response has specified number of events with required json payload:
- * <pre><blockquote>
+ * <pre>
+ *  {@code
  *
  *      import static uk.gov.justice.services.test.utils.core.http.RequestParamsBuilder.requestParams;
  *      import static uk.gov.justice.services.test.utils.core.http.RestPoller.poll;
@@ -55,8 +56,8 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *                  )
  *          )
  *      ;
- *
- * </blockquote></pre>
+ *  }
+ * </pre>
  *
  * The call is configured using <code>RequestParams</code>. This object is most easily created using
  * a <code>RequestParamsBuilder</code> which takes a url and media type and will supply all other
@@ -64,8 +65,8 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  * way.
  *
  * Poll until the response has specified substring in the payload:
- * <pre><blockquote>
- *
+ * <pre>
+ *  {@code
  *      import static uk.gov.justice.services.test.utils.core.http.RequestParamsBuilder.requestParams;
  *      import static uk.gov.justice.services.test.utils.core.http.RestPoller.poll;
  *
@@ -85,12 +86,13 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *                  )
  *          )
  *      ;
- *
- * </blockquote></pre>
+ *  }
+ * </pre>
  *
  * Poll ignoring certain response status, until the response has specified number of events with
  * required data:
- * <pre><blockquote>
+ * <pre>
+ *  {@code
  *
  *      import static uk.gov.justice.services.test.utils.core.http.RequestParamsBuilder.requestParams;
  *      import static uk.gov.justice.services.test.utils.core.http.RestPoller.poll;
@@ -122,7 +124,8 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *          )
  *      ;
  *
- * </blockquote></pre>
+ *  }
+ * </pre>
  */
 public class RestPoller {
 
@@ -224,6 +227,7 @@ public class RestPoller {
      *
      * @param timeout the timeout
      * @param unit    the unit
+     * @return the RestPoller
      */
     public RestPoller timeout(final long timeout, final TimeUnit unit) {
         this.await = this.await.with().timeout(timeout, unit);
@@ -237,6 +241,7 @@ public class RestPoller {
      *
      * @param delay the delay
      * @param unit  the unit
+     * @return the RestPoller
      */
     public RestPoller pollDelay(final long delay, final TimeUnit unit) {
         this.await = this.await.with().pollDelay(delay, unit);

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/matchers/JsonEnvelopePayloadMatcher.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/matchers/JsonEnvelopePayloadMatcher.java
@@ -17,6 +17,8 @@ public class JsonEnvelopePayloadMatcher extends TypeSafeDiagnosingMatcher<JsonVa
 
     /**
      * Use {@link JsonEnvelopePayloadMatcher#payload} or {@link JsonEnvelopePayloadMatcher#payloadIsJson}
+     *
+     * @return the payload matcher
      */
     @Deprecated
     public static JsonEnvelopePayloadMatcher payLoad() {

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/messaging/Poller.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/messaging/Poller.java
@@ -17,18 +17,20 @@ import com.google.common.annotations.VisibleForTesting;
  *
  * To use:
  *
- * <pre><blockquote>
+ * <pre>
+ *  {@code
  *
  *      private final MyResourceFinder myResourceFinder = new MyResourceFinder();
  *      private final Poller poller = new Poller();
  *
- *      @Test
+ *      {@literal @}Test
  *      public void myTest() {
  *
  *          final Optional<String> found = poller.pollUntilFound(myResourceFinder::find);
  *      }
  *
- *  </blockquote></pre>
+ *  }
+ * </pre>
  */
 public class Poller {
 

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/messaging/TopicSender.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/messaging/TopicSender.java
@@ -15,18 +15,16 @@ import javax.jms.Session;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 
 /**
- * 
- * Send messages to a JMS topic sequentially <br>
+ * Send messages to a JMS topic sequentially
  * or as a parallel stream
- * 
- * Example: <br/>
- * 
- * <code>
  *
- *  TopicSender.of(URI, "public.event").send("JMS Envelope");
- *   
- * </code>
+ * Example:
  *
+ * {@code
+ *
+ * TopicSender.of(URI, "public.event").send("JMS Envelope");
+ *
+ * }
  */
 public class TopicSender {
 
@@ -42,8 +40,8 @@ public class TopicSender {
 
     /**
      * Initialise the sender
-     * 
-     * @param uri of the JMS server
+     *
+     * @param uri   of the JMS server
      * @param topic to send messages to
      */
     private TopicSender(final String uri, final String topic) {
@@ -53,8 +51,8 @@ public class TopicSender {
 
     /**
      * Create an instance of the sender
-     * 
-     * @param uri of the JMS server
+     *
+     * @param uri   of the JMS server
      * @param topic to send messages to
      * @return TopicSender
      */
@@ -65,7 +63,7 @@ public class TopicSender {
 
     /**
      * Send a single message to the configured topic
-     * 
+     *
      * @param msg to send
      * @throws JMSException if unsuccessful
      */
@@ -83,7 +81,7 @@ public class TopicSender {
      * Send a stream of messages to the configured topic <br>
      * <br>
      * Even one of the msgs failing throws a RuntimeException
-     * 
+     *
      * @param msgs to send
      * @throws JMSException if unsuccessful
      */
@@ -103,7 +101,7 @@ public class TopicSender {
      * Send a stream of messages in parallel to the configured topic <br>
      * <br>
      * Even one of the msgs failing throws a RuntimeException
-     * 
+     *
      * @param msgs to send
      * @throws JMSException if unsuccessful
      */
@@ -121,7 +119,7 @@ public class TopicSender {
 
     /**
      * Execute the passed in operation injecting a producer and session
-     * 
+     *
      * @param op to execute
      * @throws JMSException if unsuccessful
      */

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/random/GeneratorUtil.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/random/GeneratorUtil.java
@@ -13,7 +13,7 @@ import java.util.Properties;
 /**
  * Utility class used by the email generator
  *
- * @See EmailAddressGenerator
+ * {@link EmailAddressGenerator}
  */
 public class GeneratorUtil {
 
@@ -42,6 +42,7 @@ public class GeneratorUtil {
      * @param validChars to chose from
      * @param min        length of the string
      * @param max        length of the string
+     * @return the generated String
      */
     public static String generateStringFromCharacters(final char[] validChars, final int min, final int max) {
         final int size = integer(min, max + 1).next();

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/random/PostcodeGenerator.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/random/PostcodeGenerator.java
@@ -61,41 +61,41 @@ import static java.lang.String.format;
  * Valid Formats: A indicates an alphabetic character and N indicates a numeric character
  * </p>
  * 
- * <table>
+ * <table summary="">
  * <tr>
  * <th>Outcode</th>
  * <th>Incode</th>
  * <th>Example Postcode</th>
  * </tr>
  * <tr>
- * <td>AN</th>
- * <th>NAA</th>
- * <th>M1 1AA</th>
+ * <td>AN</td>
+ * <td>NAA</td>
+ * <td>M1 1AA</td>
  * </tr>
  * <tr>
- * <td>ANN</th>
- * <th>NAA</th>
- * <th>M10 1NW</th>
+ * <td>ANN</td>
+ * <td>NAA</td>
+ * <td>M10 1NW</td>
  * </tr>
  * <tr>
- * <td>AAN</th>
- * <th>NAA</th>
- * <th>CR2 6NY</th>
+ * <td>AAN</td>
+ * <td>NAA</td>
+ * <td>CR2 6NY</td>
  * </tr>
  * <tr>
- * <td>AANN</th>
- * <th>NAA</th>
- * <th>CN65 1AP</th>
+ * <td>AANN</td>
+ * <td>NAA</td>
+ * <td>CN65 1AP</td>
  * </tr>
  * <tr>
- * <td>ANA</th>
- * <th>NAA</th>
- * <th>M1P 1AA</th>
+ * <td>ANA</td>
+ * <td>NAA</td>
+ * <td>M1P 1AA</td>
  * </tr>
  * <tr>
- * <td>AANA</th>
- * <th>NAA</th>
- * <th>EC1A 1AA</th>
+ * <td>AANA</td>
+ * <td>NAA</td>
+ * <td>EC1A 1AA</td>
  * </tr>
  * </table>
  * 
@@ -104,16 +104,13 @@ import static java.lang.String.format;
  * CIKMOV
  * </p>
  * 
- * <p>
- * 
  * <ul>
  * <li>The letters Q, V and X are not used in the first position</li>
  * <li>The letters I,J and Z are not used in the second position.</li>
  * <li>The only letters to appear in the third position are A, B, C, D, E, F, G, H, J, K, S, T, U
  * and W.</li>
  * </ul>
- * </p>
- * 
+ *
  */
 public class PostcodeGenerator extends Generator<String> {
 

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/random/RandomGenerator.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/random/RandomGenerator.java
@@ -10,7 +10,6 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.time.LocalDate;
 import java.time.Period;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
@@ -71,6 +70,9 @@ public class RandomGenerator {
     }
 
     /**
+     * @param max   the max
+     * @param scale the scale
+     * @return the BigDecimalGenerator
      * @deprecated Use {@link #bigDecimal(Integer min, Integer max, Integer scale)} instead.
      */
     @Deprecated
@@ -79,6 +81,8 @@ public class RandomGenerator {
     }
 
     /**
+     * @param max the max
+     * @return the BigDecimalGenerator
      * @deprecated Use {@link #bigDecimal(Integer min, Integer max, Integer scale)} instead.
      */
     @Deprecated
@@ -87,6 +91,9 @@ public class RandomGenerator {
     }
 
     /**
+     * @param max           the max
+     * @param decimalPlaces the decimal places
+     * @return the DoubleGenerator
      * @deprecated Use {@link #doubleValue(Long min, Long max, Integer scale)} instead.
      */
     @Deprecated

--- a/test-utils/test-utils-persistence/src/main/java/uk/gov/justice/services/test/utils/persistence/DatabaseCleaner.java
+++ b/test-utils/test-utils-persistence/src/main/java/uk/gov/justice/services/test/utils/persistence/DatabaseCleaner.java
@@ -20,9 +20,9 @@ import com.google.common.annotations.VisibleForTesting;
  *
  * To use:
  *
- * <pre><blockquote>
- *
- *     @Before
+ * <pre>
+ *  {@code
+ *     {@literal @}Before
  *     public void cleanTheDatabase() {
  *
  *          databaseCleaner.cleanStreamStatusTable(CONTEXT_NAME);
@@ -30,8 +30,8 @@ import com.google.common.annotations.VisibleForTesting;
  *          databaseCleaner.cleanEventLogTable(CONTEXT_NAME);
  *          databaseCleaner.cleanViewStoreTables(CONTEXT_NAME, "table_1", "table_2");
  *     }
- *
- * </blockquote></pre>
+ *  }
+ * </pre>
  *
  */
 public class DatabaseCleaner {


### PR DESCRIPTION
Remove all Java Doc errors and warnings, to allow mvn javadoc:javadoc to compile Java Docs without failures.