### PR TITLE
framework-api-messaging-adaptor: correct scope on test-utils

### DIFF
--- a/framework-api/framework-api-messaging-adapter/pom.xml
+++ b/framework-api/framework-api-messaging-adapter/pom.xml
@@ -51,6 +51,7 @@
             <groupId>uk.gov.justice.services</groupId>
             <artifactId>test-utils-core</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Fix corresponding missing symbol on generator for messaging-adaptor-core