### PR TITLE
switch to bintray for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,23 @@
-sudo: required
 dist: trusty
+sudo: required
 language: java
 jdk:
-  - oraclejdk8
+- oraclejdk8
+git:
+  depth: 3
 cache:
   directories:
-    - "$HOME/.m2"
+  - "$HOME/.m2"
 before_install:
-  - git clone https://github.com/CJSCommonPlatform/travis-settings.git target/travis-settings
-install:
-  - cp -f $JAVA_HOME/jre/lib/security/cacerts target/travis-settings/cacerts
-  - chmod u+w target/travis-settings/cacerts
-  - $JAVA_HOME/jre/bin/keytool -import -v -noprompt -storepass changeit -storetype jks -trustcacerts -alias IndigoBlueRoot -file target/travis-settings/ROOT-CA.crt -keystore target/travis-settings/cacerts
-script: mvn -Djavax.net.ssl.trustStore=$PWD/target/travis-settings/cacerts -B -C -V -U --settings target/travis-settings/settings.xml verify coveralls:report
-after_success:
-  - '[[ $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_TAG != release-* ]] && mvn -Djavax.net.ssl.trustStore=$PWD/target/travis-settings/cacerts -DskipTests=true -B -C -V --errors deploy --settings target/travis-settings/settings.xml'
-  - '[[ $TRAVIS_TAG == release-* ]] && mvn -Prelease -Djavax.net.ssl.trustStore=$PWD/target/travis-settings/cacerts -DskipTests=true -B -C -V --errors deploy --settings target/travis-settings/settings.xml'
+- git clone https://github.com/CJSCommonPlatform/travis-settings.git target/travis-settings
+- ln -sfT ${PWD}/target/travis-settings/settings.xml ${HOME}/.m2/settings.xml
+install: "${PWD}/target/travis-settings/java/install.sh -e -q -DexcludeGroupIds=uk.gov.justice.service,uk.gov.justice.services"
+script: "${PWD}/target/travis-settings/java/script.sh coveralls:report"
+after_success: "${PWD}/target/travis-settings/java/after_success.sh"
 notifications:
   slack:
     secure: fPlaMvrczZ2riJ4tjMOAqxSGj4JfxGlH/K08knLgG4T/n6EL4LN4+184Npz9XueNbV3m26WUrPkbXEiWXpqkKsbwcZXqqnFxGacGiyxv7LeBeQLYp7NFeARAyB5qDwUpjHlCPAEoAeyeGsZNrpui/wceY4j1tB7ObfdwbxLzAO0tekdbwitSaK1cc7V2sVHkBYr7ChuC+dVO1pshPw0EVTmzPioS8nfFKPaxWoMgyRAuYe7MD0U7DxNQ4Wzsb7tpfd5Oom1wLXyZ7M3wwSMMamIAAxHVG389Az6YvN7hXQggTGDawf/YwVOaoMR2bh7uHBCOiNZO1GbRTOA7IuTPwT7GsK94THRtfvqNm7RFBPkoD4657FATnk2o5c7QNTY3dAlYLsxLnS6mVTL/vAbqC7BbDHo/UGsxmOusQtKt8sRoL8pOCEInHaS3b88Osl7u7oYO/E4YTptdnkEe8tNyWWdx34nEUT0j1Mu/VAN38YcgTMUuiBU6chkMJ5BjIHisJlAAnBJ9VGgF9liqnigNwAGhbrHZPyAlKUX8HLejpD+t4aR0UaEvvauh6aHh4pYm0mZra4zOBC/lBDOXqsu5ajHL8LpHc6j+5FrmNwciiTVoxdud2S4c0U2ymr3L07ivX+UyhoraS9oSH3v7L73Q4NyvuAmD8Zc0xw/cR4Pff9c=
 env:
   global:
-    - secure: 1I5o+lWqnsw8LW1AY3x5QkbFko+TVyCg7dTxAKaFgDreNjDxc4K3KlgkVay6+5eZXOJNyh+xqWGWItmELubWuM1QRnfTXJWqIb9xfMvqLlWygaPRP+zOYrkrY9H4NUstKvF41tkXWmz+BNheU7HeG7x9Ts2bTJ+sVKSHC7R0waOJRGj0rn/NEWzi0FpRMwoqOxJCEno4lmkj5Sb8XOTDtCE8PwxX6/p0ICgPIjA9Ctz/2j2ZAd1REgxAHsK+g3Qe3W2Zqry6NC3Bbb0eeMjjzF7ZouVYzOjqE92CPvaUhcnlAWTLHjn/b08qFcX6Q2GNNQGJxzZ564gC44PBRRlJBdgkHCDFTFdj6ecKMgZp6cVh6ZTUdN3RVV+ti41RjIpF0ll2QR8psYsWcTywNXR1t3YdMnZQkMrQGcLbwe1Rq//DF4nahJnms8E7Q9/nW2BFgaG2y8Jt9a9pWj1URC/K2/AuLQmsQ+fxVeHh8iKifRN1F7jKHRrNZdKFzXVpTW+Pd4WL1x9+cF6syDp/aizypvcxpCM8ERowxBmwAFhDGaPns8gC7lvUuZmlTgg1HKS8IAGArTaMje6Bw0QJYu5oioXeYY+/Ae6AYb6jCgytPKPk9IDFf+mPQ5DfFnlNNNgOiKjMITGbvkIkixQWLvXO+b+Ilf76xD3r6fCNyZnVDGE=
-    - secure: RgKO2J/xG5o6MBxjkuRg1N7rHvlzHJjTwaGw3Ccv+16AQsxjygC/+OOgPWdoH9Ghi3StJjKUEpfAzGwKWJLIfCww8O8jdy21ClBjtVAnpXF4IdUY+nUvkrYVIJShk/jsPfhHg8bSV+2UcvoXXvxrqPnjkq2h56w+6LNmLfKhOms45RFgdLaDJYtrzfaWa+LvB6nRqLTbtUnaW5mc8iG25uOmTGj9OH8lZ9/hUAPh/C1PM27VAKg5qjMsRre0bZ/vDPADNL7cVAGrkR3JUp+3IVQJjl7TYtZbaQl1YfjlGwSYuWvQjJfNQmXtNTydXI1rBCGglORnOG8m7FEufK9O4m8ee4cw9gWJhJVbfQyfe2tX0Q0uaE9aZieZlJA4fNEjt++7gXyP3XHMNjkmy1N1KaGc/3Vkc5QyiGdQ+Mp1hS+Gt8MH/OXX3yIr2ozn3fXTXFSkBcHgQD+cDf077l5JPIaFRE4/IFWuWnxxWpSuOwu7lhzt+SLmiJhupmOcFWyYiHZvyUL5/+FjErdqBeyEGnozP9PvrNfR5iH3q7nOdRrsdNX96SXZwEgbLNcdnIwC2l+KTddNKuo7rVjw/df4JfdVJsIiEhcd3Y0HIDzcSRINTPrBfhDHxjfnfVD749OP0XpYry1/Xm1beGFRRWqoYQSbxkqfOGSWj/xvXlfMs34=
+  - secure: xFRshq2P7UIwiMF+k99tyTg9MxdVshGA8nzRZz2LDOcHTeTebigHoYMHCLy8u7fGcFtiJwbrU+JsFZdJXBzXbxllyfyUC5p5xRkZuO8Dz21tLelmrzee1xq+cMM64fEwO5FGqFCLT9HGiPXBTJJCp59dNsc1OKO2Whkao4Sw3BpxIu+5K2A+op6wOV7gTsXjkLk3xrxFPSu8NGsFCCpGcFs94dLvVZBzlR8crgkHBV67puhQebRIAOFd6JXCkxRmDzquOxRokawvRZFmGWFoYI45vmY30Re7ddKWGkt8OvgSaPDQCwWS9wo2nK8Y6ketWfRkkN1veg6OZz5daPZCWsTUFxxC6G1q8inxNsUf5K1DrNAaFguEbutF/ETCUrQHeSDH1YrWcO96qxBXURqEDOVQnOZxYz1z2/RVa8VfLe7HP7e7OXG5QJulBRbRf6W77Jx0ZSkFU7Ep49G1sGLcDK7sTg7ICY37nVlB9Kp7/aWu24e2OdjIYLxN0Ol1jiXUWLzp8ROmk17fnJbG3c6ADNcPAHv75FcNrUUTp8hP6Wv0I18pnFqUiorIZcuiZo2GwsALMFYMFlNuVlt770yRBE9QJLIj7HynF49Ppc0Oa6koPl3P1nncdyVk5U9vL5NpVcK+S4cjm1xY7of64KeJvncCPTbL+9kMN1/FjQzk6h8=
+  - secure: jYpqQP+l9giPz/6gtDwfc7+NFN0Dt0X18yTXqIsxU2Fq25tZ8htOfEACcrXlLuQKZE2W+C5vWrR+pNFcxCyNvncA/pMGoaLLWTqoLKmmit1jRe6DlMubbof8yCzwFSyrkkvyNFG0lB0d7gJNEKEvzsFC75Knl5/b/Kg1uMMKWgLQSHZPL1IQZTeas3CrEaRbAUiJaYbYSn5svPxLpS+ru/uifB4+EFpSvxdf3A13CXYSxlNas7kD/BG9BxUSIj3C3BeGfmARnO45gqofFREY813L12BDL4yHVsvAg6krA7lKxoYIyXYpLuVlPQg3XsaqJBEg2HfsYwvG9WH8EWYlrTIdpLWcU27VIIG1ezm5xB94xxVUQS2u3kxWKTDzJaNb3YzXuTe7kfb2pUjpbzSRBuhGzI5YjXZ7HXjqLbcCN+I0rh2keOii1ZW1LkUX3G2+V45dbDznUsVZORqMru/RiqAYVoFVFNxm+KD4e7qujCDBc1wJ9FaMmP48zWZSGom9J4zTD6/w7itZIDzu0Ld7tR0s2SS/lXcPHgZJsVZrcTZjAfCT1HamrzKTDecFgMCKw2FaiHkcHe3LfKEKAYohxN61BzMxMSYzml+/e6kKylqcGBULQQPAtnGkczAlgDsqVpg5QhZXLM2QCDf7pC9Zx54OFf77HC/22uQDOe9mQfY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 ## [Unreleased]
 
 ### Changed
-- Switched to 1.2.0.Alpha6 of the maven-wildfly-plugin, the MoJ fork is not required as the 'start' option keeps the server around in the background
-  as long as the plugin is not skipped ... which it is by default in maven-framework-parent-pom
-- in example-it move the wildfly operations to the pre/post-integration-test phases (where they belong)
+- Use maven-framework-parent-pom 1.6.1, which simply changes the wildfly-maven-plugin to 1.2.0.Alpha6 and stops adding it to every build
+- example-it: move the wildfly operations to the pre/post-integration-test phases (where they belong)
 - Switch to bintray for release processes
 - Cleaned up some unnecessary version overrides
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+### Changed
+- Switched to 1.2.0.Alpha6 of the maven-wildfly-plugin, the MoJ fork is not required as the 'start' option keeps the server around in the background
+  as long as the plugin is not skipped ... which it is by default in maven-framework-parent-pom
+- in example-it move the wildfly operations to the pre/post-integration-test phases (where they belong)
+- Switch to bintray for release processes
+- Cleaned up some unnecessary version overrides
+
 ## [2.1.0] 2017-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Clone the following CJSCommonPlatform projects into the same directory level:
 * [utilities](https://github.com/CJSCommonPlatform/utilities)
 * [file-service](https://github.com/CJSCommonPlatform/file-service)
 * [json-schema](https://github.com/CJSCommonPlatform/json-schema)
-* [wildfly-maven-plugin](https://github.com/CJSCommonPlatform/wildfly-maven-plugin)
 * [microservice_framework](https://github.com/CJSCommonPlatform/microservice_framework)
 
 #### Run dependency installation script

--- a/example-context/example-service/example-it/pom.xml
+++ b/example-context/example-service/example-it/pom.xml
@@ -9,14 +9,13 @@
     </parent>
     <artifactId>example-it</artifactId>
     <properties>
-        <jboss.home>${project.build.directory}/wildfly-10.0.0.Final</jboss.home>
+        <wildfly.version>10.0.0.Final</wildfly.version>
+        <jboss.home>${project.build.directory}/wildfly-${wildfly.version}</jboss.home>
         <!-- To be used when running CakeShopIT-->
         <server.config>standalone-test.xml</server.config>
 
         <!-- To be used when running CakeShopPostgresIT-->
         <!--<server.config>standalone-postgres-test.xml</server.config>-->
-
-        <wildfly.keepalive>false</wildfly.keepalive>
     </properties>
 
     <dependencies>
@@ -241,7 +240,7 @@
                 <executions>
                     <execution>
                         <id>unpack-wildfly</id>
-                        <phase>process-test-classes</phase>
+                        <phase>pre-integration-test</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>
@@ -259,7 +258,7 @@
                     </execution>
                     <execution>
                         <id>copy-wars</id>
-                        <phase>process-test-classes</phase>
+                        <phase>pre-integration-test</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>
@@ -369,7 +368,7 @@
                 <executions>
                     <execution>
                         <id>copy-jboss-config</id>
-                        <phase>process-test-classes</phase>
+                        <phase>pre-integration-test</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -396,7 +395,7 @@
             <!--<executions>-->
             <!--<execution>-->
             <!--<id>copy-jboss-module</id>-->
-            <!--<phase>process-test-classes</phase>-->
+            <!--<phase>pre-integration-test</phase>-->
             <!--<goals>-->
             <!--<goal>copy-resources</goal>-->
             <!--</goals>-->
@@ -427,14 +426,14 @@
                 <executions>
                     <execution>
                         <id>Spawn a new H2 TCP server</id>
-                        <phase>process-test-classes</phase>
+                        <phase>pre-integration-test</phase>
                         <goals>
                             <goal>spawn</goal>
                         </goals>
                     </execution>
                     <execution>
                         <id>Stop a spawned H2 TCP server</id>
-                        <phase>verify</phase>
+                        <phase>post-integration-test</phase>
                         <goals>
                             <goal>stop</goal>
                         </goals>
@@ -452,24 +451,27 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>1.0.2.MoJ.Fork</version>
                 <configuration>
                     <jbossHome>${jboss.home}</jbossHome>
                     <serverConfig>${server.config}</serverConfig>
-                    <keepAlive>${wildfly.keepalive}</keepAlive>
+                    <timeout>120</timeout>
                     <!--<jvmArgs>-agentlib:jdwp=transport=dt_socket,address=8888,server=y,suspend=y</jvmArgs>-->
+                    <version>${wildfly.version}</version>
                 </configuration>
                 <executions>
                     <execution>
                         <id>start-server</id>
-                        <phase>process-test-classes</phase>
+                        <phase>pre-integration-test</phase>
                         <goals>
                             <goal>start</goal>
                         </goals>
+                        <configuration>
+                            <startupTimeout>120</startupTimeout>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>stop-server</id>
-                        <phase>verify</phase>
+                        <phase>post-integration-test</phase>
                         <goals>
                             <goal>shutdown</goal>
                         </goals>

--- a/example-context/example-service/example-it/start-server-it.bat
+++ b/example-context/example-service/example-it/start-server-it.bat
@@ -1,1 +1,1 @@
-mvn -Dwildfly.keepalive=true com.edugility:h2-maven-plugin:spawn wildfly:start
+mvn com.edugility:h2-maven-plugin:spawn wildfly:start

--- a/example-context/example-service/example-it/start-server-it.sh
+++ b/example-context/example-service/example-it/start-server-it.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-mvn -Dwildfly.keepalive=true com.edugility:h2-maven-plugin:spawn wildfly:start
+mvn com.edugility:h2-maven-plugin:spawn wildfly:start

--- a/example-context/example-service/pom.xml
+++ b/example-context/example-service/pom.xml
@@ -13,7 +13,6 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.wildfly.maven.plugin>${plugins.maven.wildfly.version}</version.wildfly.maven.plugin>
         <plugins.raml-maven.version>${raml-maven-plugin.version}</plugins.raml-maven.version>
         <wiremock.service.version>1.1.0</wiremock.service.version>
         <cpp.service-component>UNKNOWN_SERVICE_COMPONENT</cpp.service-component>

--- a/example-context/example-service/pom.xml
+++ b/example-context/example-service/pom.xml
@@ -13,8 +13,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
-        <plugins.raml-maven.version>1.5.0</plugins.raml-maven.version>
+        <version.wildfly.maven.plugin>${plugins.maven.wildfly.version}</version.wildfly.maven.plugin>
+        <plugins.raml-maven.version>${raml-maven-plugin.version}</plugins.raml-maven.version>
         <wiremock.service.version>1.1.0</wiremock.service.version>
         <cpp.service-component>UNKNOWN_SERVICE_COMPONENT</cpp.service-component>
         <skip.mockito.json.validation>true</skip.mockito.json.validation>

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -36,9 +36,6 @@ file_service_versions=("release-1.8.0")
 # json-schema
 json_schema_versions=("release-1.4.1.MoJ.Fork")
 
-# wildfly-maven-plugin
-wildfly_maven_plugin_versions=("master")
-
 # Checkout and install given version
 function installVersion {
     git checkout ${1}
@@ -85,8 +82,5 @@ installVersions ${file_service_versions[@]}
 
 cd ../json-schema
 installVersions ${json_schema_versions[@]}
-
-cd ../wildfly-maven-plugin
-installVersions ${wildfly_maven_plugin_versions[@]}
 
 cd ../microservice_framework

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-framework-parent-pom</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.1</version>
     </parent>
 
     <groupId>uk.gov.justice.services</groupId>
@@ -46,13 +46,16 @@
 
     <properties>
         <h2.version>1.3.173</h2.version>
-        <common-bom.version>1.16.0</common-bom.version>
-        <embedded-artemis.version>1.0.0</embedded-artemis.version>
-        <raml-maven-plugin.version>1.5.0</raml-maven-plugin.version>
-        <file.service.version>1.8.0</file.service.version>
-        <utilities.version>1.6.0</utilities.version>
-        <test-utils.version>1.4.0</test-utils.version>
+        <common-bom.version>1.17.0</common-bom.version>
+        <embedded-artemis.version>1.1.0</embedded-artemis.version>
+        <raml-maven-plugin.version>1.6.0</raml-maven-plugin.version>
+        <file.service.version>1.9.0</file.service.version>
+        <utilities.version>1.7.0</utilities.version>
+        <test-utils.version>1.5.0</test-utils.version>
         <jboss-ejb3-ext-api.version>2.2.0.Final</jboss-ejb3-ext-api.version>
+        <plugins.maven.wildfly.version>1.2.0.Alpha6</plugins.maven.wildfly.version>
+
+        <cpp.repo.name>microservice_framework</cpp.repo.name>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <utilities.version>1.7.0</utilities.version>
         <test-utils.version>1.5.0</test-utils.version>
         <jboss-ejb3-ext-api.version>2.2.0.Final</jboss-ejb3-ext-api.version>
-        <plugins.maven.wildfly.version>1.2.0.Alpha6</plugins.maven.wildfly.version>
 
         <cpp.repo.name>microservice_framework</cpp.repo.name>
     </properties>


### PR DESCRIPTION
- Use common Travis build process
- drop use of custom MoJ fork of wildfly-maven-plugin (not required), use a more recent version
- moved wildfly operation to correct phase (pre/post-integration-test)
- Clean up some unnecessary version overrides
- Use newer dependency versions (built from bintray)