### PR TITLE
duplicate dependency and wrap cakeshop queue receivers

### DIFF
--- a/event-sourcing/event-source-api-integration-test/pom.xml
+++ b/event-sourcing/event-source-api-integration-test/pom.xml
@@ -50,11 +50,5 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>uk.gov.justice.services</groupId>
-            <artifactId>event-repository-liquibase</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
drop duplicate dependency
use try-with-resources for Queue receivers as these are expensive and the output warns you about closing them.