### PR TITLE
Allow json schema to be validated for json null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ JsonObjectMetadataBuilders in tests
 - Record new events stream into event_stream table in Event Store
 - InterceptorChainEntryProvider to be used instead of InterceptorChainProvider
 
+### Fixed
+- Allow json schema to be validated for json null values
+
 ## [2.3.2] - 2017-10-17
 
 ##Changed

--- a/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/matchers/JsonSchemaValidationMatcher.java
+++ b/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/matchers/JsonSchemaValidationMatcher.java
@@ -92,11 +92,11 @@ public class JsonSchemaValidationMatcher {
 
                     try {
                         final String pathToJsonSchema = format(JSON_SCHEMA_TEMPLATE, jsonEnvelope.metadata().name());
-                        getJsonSchemaFor(pathToJsonSchema).validate(new JSONObject(jsonEnvelope.payloadAsJsonObject().toString()));
+                        getJsonSchemaFor(pathToJsonSchema).validate(new JSONObject(jsonEnvelope.payload().toString()));
                     } catch (final IllegalArgumentException | IOException e) {
                         try {
                             final String pathToJsonSchema = format(RAML_JSON_SCHEMA_TEMPLATE, jsonEnvelope.metadata().name());
-                            getJsonSchemaFor(pathToJsonSchema).validate(new JSONObject(jsonEnvelope.payloadAsJsonObject().toString()));
+                            getJsonSchemaFor(pathToJsonSchema).validate(new JSONObject(jsonEnvelope.payload().toString()));
                         } catch (final IOException ioe) {
                             throw new IllegalArgumentException(ioe);
                         }


### PR DESCRIPTION
The PR is to allow json schema validation matcher to validate schema for allowing json null value.

E.g.: Below test case will fail with error 

> ClassCastException: javax.json.JsonValue$1 cannot be cast to javax.json.JsonObject

`        assertThat(actualPersonResults, is(jsonEnvelope(
                withMetadataEnvelopedFrom(query)
                        .withName(RESPONSE_NAME_PERSON_DETAILS),
                payload(isJsonValueNull()))
                .thatMatchesSchema()
`
And the PR should allow schema validation possible