### PR TITLE
Use different validation interceptor for event listeners

### DIFF
--- a/generators/messaging-adapter-core/src/main/java/uk/gov/justice/services/adapter/messaging/EventListenerValidationInterceptor.java
+++ b/generators/messaging-adapter-core/src/main/java/uk/gov/justice/services/adapter/messaging/EventListenerValidationInterceptor.java
@@ -1,0 +1,21 @@
+package uk.gov.justice.services.adapter.messaging;
+
+import static uk.gov.justice.services.messaging.jms.HeaderConstants.JMS_HEADER_CPPNAME;
+
+import uk.gov.justice.services.event.buffer.api.EventFilter;
+
+import javax.inject.Inject;
+import javax.jms.JMSException;
+import javax.jms.TextMessage;
+
+public class EventListenerValidationInterceptor extends JsonSchemaValidationInterceptor {
+
+    @Inject
+    EventFilter eventFilter;
+
+    @Override
+    public boolean shouldValidate(final TextMessage message) throws JMSException {
+        final String messageName = message.getStringProperty(JMS_HEADER_CPPNAME);
+        return eventFilter.accepts(messageName);
+    }
+}

--- a/generators/messaging-adapter-core/src/main/java/uk/gov/justice/services/adapter/messaging/JsonSchemaValidationInterceptor.java
+++ b/generators/messaging-adapter-core/src/main/java/uk/gov/justice/services/adapter/messaging/JsonSchemaValidationInterceptor.java
@@ -5,7 +5,6 @@ import static uk.gov.justice.services.messaging.jms.HeaderConstants.JMS_HEADER_C
 
 import uk.gov.justice.services.core.json.JsonSchemaValidator;
 import uk.gov.justice.services.core.json.JsonValidationLoggerHelper;
-import uk.gov.justice.services.event.buffer.api.EventFilter;
 import uk.gov.justice.services.messaging.logging.JmsMessageLoggerHelper;
 
 import javax.inject.Inject;
@@ -32,9 +31,6 @@ public class JsonSchemaValidationInterceptor {
     JsonSchemaValidator validator;
 
     @Inject
-    EventFilter eventFilter;
-
-    @Inject
     JsonValidationLoggerHelper jsonValidationLoggerHelper;
 
     @Inject
@@ -47,12 +43,15 @@ public class JsonSchemaValidationInterceptor {
         parametersChecker.check(parameters);
 
         final TextMessage message = (TextMessage) parameters[0];
-        final String messageName = message.getStringProperty(JMS_HEADER_CPPNAME);
-        if (eventFilter.accepts(messageName)) {
+        if (shouldValidate(message)) {
             validate(message);
         }
 
         return context.proceed();
+    }
+
+    protected boolean shouldValidate(final TextMessage message) throws JMSException {
+        return true;
     }
 
     private void validate(final TextMessage message) throws JMSException {

--- a/generators/messaging-adapter-core/src/test/java/uk/gov/justice/services/adapter/messaging/EventListenerValidationInterceptorTest.java
+++ b/generators/messaging-adapter-core/src/test/java/uk/gov/justice/services/adapter/messaging/EventListenerValidationInterceptorTest.java
@@ -5,11 +5,13 @@ import static org.hamcrest.core.IsSame.sameInstance;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.services.messaging.jms.HeaderConstants.JMS_HEADER_CPPNAME;
 
 import uk.gov.justice.services.core.json.JsonSchemaValidator;
 import uk.gov.justice.services.core.json.JsonValidationLoggerHelper;
+import uk.gov.justice.services.event.buffer.api.EventFilter;
 import uk.gov.justice.services.messaging.logging.JmsMessageLoggerHelper;
 
 import javax.interceptor.InvocationContext;
@@ -27,7 +29,7 @@ import org.slf4j.Logger;
  * Unit tests for the {@link JsonSchemaValidationInterceptor} class.
  */
 @RunWith(MockitoJUnitRunner.class)
-public class JsonSchemaValidationInterceptorTest {
+public class EventListenerValidationInterceptorTest {
 
     @Mock
     Logger logger;
@@ -47,8 +49,11 @@ public class JsonSchemaValidationInterceptorTest {
     @Mock
     private JmsMessageLoggerHelper jmsMessageLoggerHelper;
 
+    @Mock
+    private EventFilter eventFilter;
+
     @InjectMocks
-    private JsonSchemaValidationInterceptor interceptor;
+    private EventListenerValidationInterceptor interceptor;
 
     @Test
     public void shouldReturnContextProceed() throws Exception {
@@ -69,11 +74,28 @@ public class JsonSchemaValidationInterceptorTest {
 
         when(message.getText()).thenReturn(payload);
         when(message.getStringProperty(JMS_HEADER_CPPNAME)).thenReturn(name);
+        when(eventFilter.accepts(name)).thenReturn(true);
         when(invocationContext.getParameters()).thenReturn(new Object[]{message});
 
         interceptor.validate(invocationContext);
 
         verify(validator).validate(payload, name);
+    }
+
+    @Test
+    public void shouldNotValidateUnsupportedMessage() throws Exception {
+        final TextMessage message = mock(TextMessage.class);
+        final String payload = "test payload";
+        final String name = "test-name-abc";
+
+        when(message.getText()).thenReturn(payload);
+        when(message.getStringProperty(JMS_HEADER_CPPNAME)).thenReturn(name);
+        when(eventFilter.accepts(name)).thenReturn(false);
+        when(invocationContext.getParameters()).thenReturn(new Object[]{message});
+
+        interceptor.validate(invocationContext);
+
+        verifyZeroInteractions(validator);
     }
 
     @Test(expected = ValidationException.class)
@@ -84,6 +106,7 @@ public class JsonSchemaValidationInterceptorTest {
 
         when(message.getText()).thenReturn(payload);
         when(message.getStringProperty(JMS_HEADER_CPPNAME)).thenReturn(name);
+        when(eventFilter.accepts(name)).thenReturn(true);
         when(invocationContext.getParameters()).thenReturn(new Object[]{message});
         doThrow(mock(ValidationException.class)).when(validator).validate(payload, name);
 

--- a/generators/messaging-adapter-generator/src/main/java/uk/gov/justice/raml/jms/core/JmsEndPointGeneratorUtil.java
+++ b/generators/messaging-adapter-generator/src/main/java/uk/gov/justice/raml/jms/core/JmsEndPointGeneratorUtil.java
@@ -1,0 +1,32 @@
+package uk.gov.justice.raml.jms.core;
+
+import static uk.gov.justice.raml.jms.core.MediaTypesUtil.containsGeneralJsonMimeType;
+import static uk.gov.justice.services.core.annotation.Component.EVENT_LISTENER;
+
+import uk.gov.justice.services.generators.commons.helper.MessagingAdapterBaseUri;
+
+import org.raml.model.Resource;
+
+public class JmsEndPointGeneratorUtil {
+    /*
+    Two things here:
+    1. If raml contains general json (application/json) then it means that we accept all messages, so no filter should be generated
+    2. For event listeners we let all message through the listener and then filter them after they pass event buffer service.
+    Therefore we need a generated filter based on raml.
+
+    Note: Event buffer service contains functionality that puts messages in correct order basing on version number,
+    therefore we need all messages with consecutive numbers there. Messages need to be in correct order in order to update the view correctly.
+    */
+
+    private JmsEndPointGeneratorUtil() {
+
+    }
+
+    static boolean shouldGenerateEventFilter(final Resource resource, final MessagingAdapterBaseUri baseUri) {
+        return EVENT_LISTENER.equals(baseUri.component()) && !containsGeneralJsonMimeType(resource.getActions());
+    }
+
+    static boolean shouldListenToAllMessages(final Resource resource, final MessagingAdapterBaseUri baseUri) {
+        return EVENT_LISTENER.equals(baseUri.component()) || containsGeneralJsonMimeType(resource.getActions());
+    }
+}

--- a/generators/messaging-adapter-generator/src/main/java/uk/gov/justice/raml/jms/core/JmsEndpointGenerator.java
+++ b/generators/messaging-adapter-generator/src/main/java/uk/gov/justice/raml/jms/core/JmsEndpointGenerator.java
@@ -1,8 +1,8 @@
 package uk.gov.justice.raml.jms.core;
 
 import static org.raml.model.ActionType.POST;
-import static uk.gov.justice.raml.jms.core.MediaTypesUtil.containsGeneralJsonMimeType;
-import static uk.gov.justice.services.core.annotation.Component.EVENT_LISTENER;
+import static uk.gov.justice.raml.jms.core.JmsEndPointGeneratorUtil.shouldGenerateEventFilter;
+import static uk.gov.justice.raml.jms.core.JmsEndPointGeneratorUtil.shouldListenToAllMessages;
 import static uk.gov.justice.services.generators.commons.helper.GeneratedClassWriter.writeClass;
 
 import uk.gov.justice.raml.core.Generator;
@@ -68,23 +68,4 @@ public class JmsEndpointGenerator implements Generator {
                 ? Stream.of(messageListenerCode, eventFilterCodeGenerator.generatedCodeFor(resource, baseUri))
                 : Stream.of(messageListenerCode);
     }
-
-    /*
-    Two things here:
-    1. If raml contains general json (application/json) then it means that we accept all messages, so no filter should be generated
-    2. For event listeners we let all message through the listener and then filter them after they pass event buffer service.
-    Therefore we need a generated filter based on raml.
-
-    Note: Event buffer service contains functionality that puts messages in correct order basing on version number,
-    therefore we need all messages with consecutive numbers there. Messages need to be in correct order in order to update the view correctly.
-    */
-
-    private boolean shouldGenerateEventFilter(final Resource resource, final MessagingAdapterBaseUri baseUri) {
-        return EVENT_LISTENER.equals(baseUri.component()) && !containsGeneralJsonMimeType(resource.getActions());
-    }
-
-    private boolean shouldListenToAllMessages(final Resource resource, final MessagingAdapterBaseUri baseUri) {
-        return EVENT_LISTENER.equals(baseUri.component()) || containsGeneralJsonMimeType(resource.getActions());
-    }
-
 }

--- a/generators/messaging-adapter-generator/src/test/java/uk/gov/justice/raml/jms/it/AbstractJmsAdapterGenerationIT.java
+++ b/generators/messaging-adapter-generator/src/test/java/uk/gov/justice/raml/jms/it/AbstractJmsAdapterGenerationIT.java
@@ -90,4 +90,11 @@ public abstract class AbstractJmsAdapterGenerationIT {
         return connection;
     }
 
+    protected Session getSession() throws JMSException {
+        try {
+            return getConnection().createSession(false, Session.AUTO_ACKNOWLEDGE);
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }


### PR DESCRIPTION
Fix the issue with no JSON schema validation for handlers due single war Event listener EventFilter (priority 2) loaded always and hence skips Handler validation due to no message selector name match