### PR TITLE
Do not shutter the JmsEnvelopeSender when a Command-Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 ## [6.1.2] - 2018-10-04
 ### Changed
 - Storing of Commands whilst shuttered is now idempotent 
+- Do not shutter the JmsEnvelopeSender when called from the Command-Controller component
 
 ## [6.1.1] - 2018-10-01
 ### Added

--- a/messaging/messaging-jms/src/main/java/uk/gov/justice/services/messaging/jms/JmsEnvelopeSenderProducer.java
+++ b/messaging/messaging-jms/src/main/java/uk/gov/justice/services/messaging/jms/JmsEnvelopeSenderProducer.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.services.messaging.jms;
 
+import static uk.gov.justice.services.core.annotation.Component.COMMAND_CONTROLLER;
+
 import uk.gov.justice.services.common.annotation.ComponentNameExtractor;
 
 import javax.enterprise.inject.Produces;
@@ -20,10 +22,14 @@ public class JmsEnvelopeSenderProducer {
     @Produces
     public JmsEnvelopeSender createJmsEnvelopeSender(final InjectionPoint injectionPoint) {
 
-        if (componentNameExtractor.hasComponentAnnotation(injectionPoint)) {
+        if (componentNameExtractor.hasComponentAnnotation(injectionPoint) && !isCommandController(injectionPoint)) {
             return new ShutteringJmsEnvelopeSender(envelopeSenderSelector);
         }
 
         return new DefaultJmsEnvelopeSender(jmsSender);
+    }
+
+    private boolean isCommandController(final InjectionPoint injectionPoint) {
+        return COMMAND_CONTROLLER.equals(componentNameExtractor.componentFrom(injectionPoint));
     }
 }

--- a/messaging/messaging-jms/src/test/java/uk/gov/justice/services/messaging/jms/JmsEnvelopeSenderProducerTest.java
+++ b/messaging/messaging-jms/src/test/java/uk/gov/justice/services/messaging/jms/JmsEnvelopeSenderProducerTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 import static uk.gov.justice.services.core.annotation.Component.COMMAND_API;
+import static uk.gov.justice.services.core.annotation.Component.COMMAND_CONTROLLER;
 import static uk.gov.justice.services.core.annotation.Component.EVENT_PROCESSOR;
 import static uk.gov.justice.services.core.annotation.Component.QUERY_API;
 import static uk.gov.justice.services.test.utils.common.MemberInjectionPoint.injectionPointWithMemberAsFirstMethodOf;
@@ -32,6 +33,7 @@ public class JmsEnvelopeSenderProducerTest {
     private InjectionPoint adaptorEventProcessorInjectionPoint = injectionPointWithMemberAsFirstMethodOf(TestEventProcessorAdaptor.class);
     private InjectionPoint adaptorQueryApiInjectionPoint = injectionPointWithMemberAsFirstMethodOf(TestQueryApiAdaptor.class);
     private InjectionPoint noAnnotationInjectionPoint = injectionPointWithMemberAsFirstMethodOf(TestNoAnnotation.class);
+    private InjectionPoint adaptorCommandControllerInjectionPoint = injectionPointWithMemberAsFirstMethodOf(TestCommandControllerAdaptor.class);
 
     @Mock
     private JmsSender jmsSender;
@@ -66,6 +68,14 @@ public class JmsEnvelopeSenderProducerTest {
         final JmsEnvelopeSender jmsEnvelopeSender = jmsEnvelopeSenderProducer.createJmsEnvelopeSender(adaptorEventProcessorInjectionPoint);
 
         assertThat(jmsEnvelopeSender, is(instanceOf(ShutteringJmsEnvelopeSender.class)));
+    }
+
+    @Test
+    public void shouldProduceDefaultJmsEnvelopeSenderWhenCommandControllerAnnotation() {
+
+        final JmsEnvelopeSender jmsEnvelopeSender = jmsEnvelopeSenderProducer.createJmsEnvelopeSender(adaptorCommandControllerInjectionPoint);
+
+        assertThat(jmsEnvelopeSender, is(instanceOf(DefaultJmsEnvelopeSender.class)));
     }
 
     @Test
@@ -138,6 +148,16 @@ public class JmsEnvelopeSenderProducerTest {
 
         @Inject
         JmsEnvelopeSender jmsEnvelopeSender;
+
+        public void dummyMethod() {
+        }
+    }
+
+    @FrameworkComponent(COMMAND_CONTROLLER)
+    public static class TestCommandControllerAdaptor {
+
+        @Inject
+        InterceptorChainProcessor interceptorChainProcessor;
 
         public void dummyMethod() {
         }


### PR DESCRIPTION
Do not shutter the JmsEnvelopeSender when called from the Command-Controller component